### PR TITLE
delete resource sequence reversion

### DIFF
--- a/bpmn/so-bpmn-infrastructure-common/src/main/groovy/org/onap/so/bpmn/infrastructure/scripts/DoDeleteResourcesV1.groovy
+++ b/bpmn/so-bpmn-infrastructure-common/src/main/groovy/org/onap/so/bpmn/infrastructure/scripts/DoDeleteResourcesV1.groovy
@@ -175,7 +175,7 @@ public class DoDeleteResourcesV1 extends AbstractServiceTaskProcessor {
             //this is defaule sequence
             List<VnfResource> vnfResourceList = new ArrayList<VnfResource>()
             List<AllottedResource> arResourceList = new ArrayList<AllottedResource>()
-            for (Resource rc : delResourceList) {
+            for (Resource rc : delResourceList.reverse()) {
                 if (rc instanceof VnfResource) {
                     vnfResourceList.add(rc)
                 } else if (rc instanceof NetworkResource) {


### PR DESCRIPTION
The resource deletion sequence should be reversed in the second condition also as it is reversed in the if condition. Unless it will be deleted as the resource is created and it violates the Tosca implementation mechanism.